### PR TITLE
Added timeout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn
 yarn build
 
 mkdir output error
-yarn start '/path/to/takeout/Google Fotos' './output' './error'
+yarn start '/path/to/takeout/Google Fotos' './output' './error' --timeout 60000
 ```
 
 ## Further steps


### PR DESCRIPTION
Recently added timeout parameter is mandatory, otherwise error occurs

```
$ node ./build/cli.js ../Google/Takeout2/ output error
error: found 1 error

  1. No value provided for --timeout

hint: for more information, try 'google-photos-migrate --help'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

So added it to README. 