### PR TITLE
Add Dockerfile, fix README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# we need some image and video processing tools too, so use Debian 12 "Bookworm" as the base so we can get them.
+FROM docker.io/node:bookworm
+
+# get our image and video processing dependencies
+RUN apt-get update && apt-get install -y ffmpeg exiftool
+
+COPY . /app
+
+WORKDIR /app
+# build the application
+RUN yarn && yarn build
+
+ENTRYPOINT [ "yarn", "start" ]


### PR DESCRIPTION
Add a Dockerfile that just wraps the code into a Debian 12 Bookworm node.js container and sets it as the entrypoint.  
Add instructions to the README on building the docker image manually, and running it as a one-shot container.  
Fix a mistake in the subcommands in the README.  
Add some additional detail to the fullMigrate command about what folders are created.

--- 

I've successfully built and run this to get help text, and I've run the `fullMigrate` as a one-shot container call on an actual Takeout folder with the same results as the current code when run directly on it.

/closes #13 
/closes #8 