### PR TITLE
Pin Dockerfile Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # we need some image and video processing tools too, so use Debian 12 "Bookworm" as the base so we can get them.
-FROM docker.io/node:bookworm
+FROM docker.io/node:18-bookworm
 
 # get our image and video processing dependencies
 RUN apt-get update && apt-get install -y ffmpeg exiftool


### PR DESCRIPTION
Fixes the error when building:

```
# docker build . -t localhost/google-photos-migrate:latest
<...>
9.600 error eslint@9.3.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || ^20.9.0 || >=21.1.0". Got "21.0.0"
9.605 error Found incompatible module.
```

Need to pin it since the bookworm tag pulls the Node 20 image now.