### PR TITLE
Support for Japanese and setting file modification time to photo taken time

### DIFF
--- a/src/config/langs.ts
+++ b/src/config/langs.ts
@@ -5,12 +5,14 @@ export const editedSuffices = [
   'düzenlendi',
   'измененный',
   'ha editado',
+  '編集済み',
 ];
 export const photosDirs = [
   'Google Photos',
   'Google Fotos',
   'Google Fotoğraflar',
   'Google Фото',
+  'Google フォト',
 ];
 export const untitledDirs = [
   'Untitled',
@@ -18,4 +20,5 @@ export const untitledDirs = [
   'Adsız',
   'Без названия',
   'Sin título',
+  '無題',
 ];

--- a/src/meta/apply-meta-file.ts
+++ b/src/meta/apply-meta-file.ts
@@ -1,5 +1,6 @@
 import { WriteTags } from 'exiftool-vendored';
 import { readFile } from 'fs/promises';
+import { utimes } from 'fs/promises';
 import { MigrationContext } from '../dir/migrate-flat';
 import { MediaFile } from '../media/MediaFile';
 import { exhaustiveCheck } from '../ts';
@@ -81,6 +82,9 @@ export async function applyMetaFile(
       '-api',
       'largefilesupport=1',
     ]);
+
+    // Set file modification times to the photo taken timestamp
+    await utimes(mediaFile.path, timeTaken, timeTaken);
   } catch (e) {
     if (e instanceof Error) {
       const wrongExtMatch = e.message.match(


### PR DESCRIPTION
Thank you for the wonderful code. While using it, I came up with some improvements, so I am submitting this pull request.

* To improve file management in file explorers, the modification time of files is now set to the photo taken time. This ensures that files are organized based on when they were captured, making it easier to sort and manage them chronologically.
* Added support for Google Takeout files in Japanese.